### PR TITLE
begin tiling

### DIFF
--- a/lib/components/tiler.ex
+++ b/lib/components/tiler.ex
@@ -14,13 +14,13 @@ defmodule Fractals.Components.Tiler do
       fn graph ->
         graph
         # top left
-        |> rect({600, 600}, id: "r00", translate: {0, 0}, fill: {:stream, "r00"})
+        |> rect({600, 600}, id: "t00", translate: {0, 0}, fill: {:stream, "t00"})
         # top right
-        |> rect({600, 600}, id: "r10", translate: {600, 0}, fill: {:stream, "r10"})
+        |> rect({600, 600}, id: "t10", translate: {599, 0}, fill: {:stream, "t10"})
         # bottom left
-        |> rect({600, 600}, id: "r01", translate: {0, 600}, fill: :blue)
+        |> rect({600, 600}, id: "t01", translate: {0, 599}, fill: {:stream, "t01"})
         # bottom right
-        |> rect({600, 600}, id: "r11", translate: {600, 600}, fill: :green)
+        |> rect({600, 600}, id: "t11", translate: {599, 599}, fill: {:stream, "t11"})
       end,
       translate: translate
     )

--- a/lib/components/tiler.ex
+++ b/lib/components/tiler.ex
@@ -1,0 +1,35 @@
+defmodule Fractals.Components.Tiler do
+  use Scenic.Component
+  import Scenic.Primitives, only: [rect: 3]
+
+  require Logger
+
+  @impl Scenic.Component
+  def validate({_upper_left, _lower_right} = coords), do: {:ok, coords}
+  def validate(_), do: :invalid_data
+
+  def graph(translate) do
+    Scenic.Graph.build()
+    |> Scenic.Primitives.group(
+      fn graph ->
+        graph
+        # top left
+        |> rect({600, 600}, id: "r00", translate: {0, 0}, fill: {:stream, "r00"})
+        # top right
+        |> rect({600, 600}, id: "r10", translate: {600, 0}, fill: {:stream, "r10"})
+        # bottom left
+        |> rect({600, 600}, id: "r01", translate: {0, 600}, fill: :blue)
+        # bottom right
+        |> rect({600, 600}, id: "r11", translate: {600, 600}, fill: :green)
+      end,
+      translate: translate
+    )
+  end
+
+  @impl Scenic.Scene
+  def init(scene, {_size, translate}, _opts) do
+    graph = graph(translate)
+
+    {:ok, push_graph(scene, graph)}
+  end
+end

--- a/lib/components/tiler.ex
+++ b/lib/components/tiler.ex
@@ -14,13 +14,29 @@ defmodule Fractals.Components.Tiler do
       fn graph ->
         graph
         # top left
-        |> rect({600, 600}, id: "t00", translate: {0, 0}, fill: {:stream, "t00"})
+        |> rect({600, 600},
+          id: "t00",
+          translate: {0, 0},
+          fill: {:stream, "t00"}
+        )
         # top right
-        |> rect({600, 600}, id: "t10", translate: {600, 0}, fill: {:stream, "t10"})
+        |> rect({600, 600},
+          id: "t10",
+          translate: {600, 0},
+          fill: {:stream, "t10"}
+        )
         # # bottom left
-        |> rect({600, 600}, id: "t01", translate: {0, 600}, fill: {:stream, "t01"})
+        |> rect({600, 600},
+          id: "t01",
+          translate: {0, 600},
+          fill: {:stream, "t01"}
+        )
         # bottom right
-        |> rect({600, 600}, id: "t11", translate: {600, 600}, fill: {:stream, "t11"})
+        |> rect({600, 600},
+          id: "t11",
+          translate: {600, 600},
+          fill: {:stream, "t11"}
+        )
       end,
       translate: translate
     )

--- a/lib/components/tiler.ex
+++ b/lib/components/tiler.ex
@@ -16,11 +16,11 @@ defmodule Fractals.Components.Tiler do
         # top left
         |> rect({600, 600}, id: "t00", translate: {0, 0}, fill: {:stream, "t00"})
         # top right
-        |> rect({600, 600}, id: "t10", translate: {599, 0}, fill: {:stream, "t10"})
-        # bottom left
-        |> rect({600, 600}, id: "t01", translate: {0, 599}, fill: {:stream, "t01"})
+        |> rect({600, 600}, id: "t10", translate: {600, 0}, fill: {:stream, "t10"})
+        # # bottom left
+        |> rect({600, 600}, id: "t01", translate: {0, 600}, fill: {:stream, "t01"})
         # bottom right
-        |> rect({600, 600}, id: "t11", translate: {599, 599}, fill: {:stream, "t11"})
+        |> rect({600, 600}, id: "t11", translate: {600, 600}, fill: {:stream, "t11"})
       end,
       translate: translate
     )

--- a/lib/fractals/tile_server.ex
+++ b/lib/fractals/tile_server.ex
@@ -1,0 +1,19 @@
+defmodule Fractals.TileServer do
+  alias Scenic.Assets.Stream
+
+  def generate_tiles({upper_left, lower_right}, {rows, cols}) do
+    tile_width = (lower_right.re - upper_left.re) / cols
+    tile_height = (upper_left.im - lower_right.im) / rows
+
+    for row <- 0..(rows - 1), col <- 0..(cols - 1) do
+      upper_left = %{re: upper_left.re + tile_width * col, im: upper_left.im - tile_height * row}
+      lower_right = %{re: upper_left.re + tile_width, im: upper_left.im - tile_height}
+
+      bin =
+        Fractals.Generate.generate({600, 600}, {upper_left, lower_right}) |> :binary.list_to_bin()
+
+      {:ok, img} = Stream.Image.from_binary(bin)
+      Stream.put("t#{col}#{row}", img)
+    end
+  end
+end

--- a/lib/scenes/home.ex
+++ b/lib/scenes/home.ex
@@ -2,8 +2,8 @@ defmodule Fractals.Scene.Home do
   use Scenic.Scene
   require Logger
 
-  @upper_left %{re: -2.5, im: 2.5}
-  @lower_right %{re: 2.5, im: -2.5}
+  @upper_left %{re: -2.05, im: 2.25}
+  @lower_right %{re: 2.05, im: -2.75}
   @starting_coords {@upper_left, @lower_right}
 
   @graph [] |> Scenic.Graph.build()

--- a/lib/scenes/home.ex
+++ b/lib/scenes/home.ex
@@ -4,20 +4,17 @@ defmodule Fractals.Scene.Home do
 
   alias Scenic.Assets.Stream
 
-  import Scenic.Primitives
-
-  @upper_left %{re: -2.05, im: 2.25}
-  @lower_right %{re: 2.05, im: -2.75}
+  @upper_left %{re: -2.5, im: 2.5}
+  @lower_right %{re: 2.5, im: -2.5}
   @starting_coords {@upper_left, @lower_right}
 
   @graph [] |> Scenic.Graph.build()
 
   def graph(viewport, {_ul, _lr} = coords) do
+    translate = {100, 300}
+
     @graph
-    |> rect(viewport.size,
-      fill: {:stream, "fractal"},
-      input: [:relative]
-    )
+    |> Fractals.Components.Tiler.add_to_graph({viewport.size, translate}, id: :tiler)
     |> Fractals.Components.Nav.add_to_graph(coords, id: :nav)
   end
 
@@ -42,9 +39,6 @@ defmodule Fractals.Scene.Home do
   def handle_event({:new_coords, coords}, _from, scene) do
     if coords != scene.assigns.coords do
       Logger.info("#{__MODULE__}: Updating Coords!\nNew Coords: #{inspect(coords)}")
-      bin = coords |> Fractals.Generate.generate() |> :binary.list_to_bin()
-      {:ok, img} = Stream.Image.from_binary(bin)
-      Stream.put("fractal", img)
 
       graph = graph(scene.viewport, coords)
 

--- a/lib/scenes/home.ex
+++ b/lib/scenes/home.ex
@@ -2,8 +2,6 @@ defmodule Fractals.Scene.Home do
   use Scenic.Scene
   require Logger
 
-  alias Scenic.Assets.Stream
-
   @upper_left %{re: -2.5, im: 2.5}
   @lower_right %{re: 2.5, im: -2.5}
   @starting_coords {@upper_left, @lower_right}
@@ -11,7 +9,7 @@ defmodule Fractals.Scene.Home do
   @graph [] |> Scenic.Graph.build()
 
   def graph(viewport, {_ul, _lr} = coords) do
-    translate = {100, 300}
+    translate = {0, 0}
 
     @graph
     |> Fractals.Components.Tiler.add_to_graph({viewport.size, translate}, id: :tiler)
@@ -20,9 +18,7 @@ defmodule Fractals.Scene.Home do
 
   @impl true
   def init(scene, _param, _opts) do
-    bin = @starting_coords |> Fractals.Generate.generate() |> :binary.list_to_bin()
-    {:ok, img} = Stream.Image.from_binary(bin)
-    Stream.put("fractal", img)
+    Fractals.TileServer.generate_tiles({@upper_left, @lower_right}, {2, 2})
 
     graph = graph(scene.viewport, {@upper_left, @lower_right})
 


### PR DESCRIPTION
Instead of rendering one big image, generate a group of tiles. The idea is to be able to pre-generate tiles, cache them, and ensure they are larger than the viewport so the user can move left and right without making expensive render calls.

This PR will be complete when the same functionality as main exists (click navigation) but tiles are generated instead of one big image. There might be a performance hit, but it should be solved with caching in a follow up PR.

TODO
- [ ] generate 4 images instead of 1
- [ ] implement scrolling and zoom